### PR TITLE
 The config parameter for the URL to our Canvas installation should b…

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -33,7 +33,7 @@ A configuration file should be included in the same directory where nbgrader ope
 ### Canvas
 
 <dl>
-  <dt><code>c.Canvas.course_url</code> - <em>str</em></dt>
+  <dt><code>c.Canvas.canvas_url</code> - <em>str</em></dt>
   <dd>
     The URL of your Canvas distribution.
     <p class='extra-dl-info'>


### PR DESCRIPTION
…e “canvas_url”, not “course_url”